### PR TITLE
Fix EFD: complex array

### DIFF
--- a/pysdkit/_emd/efd.py
+++ b/pysdkit/_emd/efd.py
@@ -89,7 +89,7 @@ class EFD(object):
         imfs = np.zeros(shape=(number, len(signal)))
 
         # The results are stored in the frequency domain
-        ft = np.zeros([number, len(ff)])
+        ft = np.zeros([number, len(ff)], dtype=complex)
 
         # We define an ideal functions and extract components
         for k in range(0, number):


### PR DESCRIPTION
Thank you very much for your efforts to provide a mode decomposition library!

I noticed a small error in the EFD implementation. The current algorithm decomposes wrong modes that are always symmetric. This can be fixed by using a complex array for computations in frequency domain.


[orig.pdf](https://github.com/user-attachments/files/21254407/orig.pdf)

[fixed.pdf](https://github.com/user-attachments/files/21254411/fixed.pdf)

[data.txt](https://github.com/user-attachments/files/21254559/data.txt)


